### PR TITLE
Adds searching for MariaDB and LibUV libs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ project("ModuleDevelopmentKit")
 option(WITH_SQLITE "Enable SQLite support" ON)
 option(WITH_MARIADB "Enable MariaDB support" ON)
 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ModuleDevelopmentKit_SOURCE_DIR}/cmake)
+
 # Add definitions for w32 build that dosen't support _WIN32 macro
 if (WIN32)
 	add_definitions("-DWIN32 -D__WIN32__")
@@ -32,9 +34,20 @@ endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+# Find thread libraries and compiler flags if required.
+find_package(Threads)
+
 # LibUV inclusions
-add_subdirectory(libuv)
-include_directories("libuv/include")
+find_package(LibUV)
+
+if(NOT LIBUV_FOUND)
+	message("Failed to find libmariadb, will build bundled copy.")
+	add_subdirectory(libuv)
+	include_directories("libuv/include")
+	set(LIBUV_LIBRARIES uv_a)
+else()
+	include_directories(${LIBUV_INCLUDE_DIRS})
+endif()
 
 # Main MDK inclusions
 include_directories("include/MDK")
@@ -42,17 +55,23 @@ include_directories("include/MDK")
 # SQLite inclusion
 if (WITH_SQLITE)
 	add_subdirectory(sqlite3)
-	add_definitions(-D__SQLITE__)
 	include_directories(sqlite3)
 endif()
 
 # Mariadb inclusion
 if (WITH_MARIADB)
-	set(WITH_UNIT_TESTS OFF) # Remove useless tests from mariadb build
-	add_subdirectory(mariadb-connector-c)
-	include_directories("mariadb-connector-c/include")
-	include_directories("${CMAKE_CURRENT_BINARY_DIR}/mariadb-connector-c/include") # mariadb config
-	add_definitions(-D__MARIADB__)
+	find_package(MariaDB)
+
+	if(NOT MARIADB_FOUND)
+		message("Failed to find libmariadb, will build bundled copy.")
+		set(WITH_UNIT_TESTS OFF) # Remove useless tests from mariadb build
+		add_subdirectory(mariadb-connector-c)
+		include_directories("mariadb-connector-c/include")
+		include_directories("${CMAKE_CURRENT_BINARY_DIR}/mariadb-connector-c/include") # mariadb config
+		set(MARIADB_LIBRARIES libmariadb)
+	else()
+		include_directories(${MARIADB_INCLUDE_DIRS})
+	endif()
 endif()
 
 set(SOURCES
@@ -81,11 +100,12 @@ if (WIN32)
 	set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/Common.rc PROPERTIES LANGUAGE RC)
 endif()
 
-set(MDK_LIBRARIES uv_a)
+set(MDK_LIBRARIES ${MDK_LIBRARIES} ${LIBUV_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 if (WITH_MARIADB)
-	set(MDK_LIBRARIES ${MDK_LIBRARIES} libmariadb)
+	set(MDK_LIBRARIES ${MDK_LIBRARIES} ${MARIADB_LIBRARIES})
 endif()
+
 if (WITH_SQLITE)
 	set(MDK_LIBRARIES ${MDK_LIBRARIES} sqlite3)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ find_package(Threads)
 find_package(LibUV)
 
 if(NOT LIBUV_FOUND)
-	message("Failed to find libmariadb, will build bundled copy.")
+	message("Failed to find libuv, will build bundled copy.")
 	add_subdirectory(libuv)
 	include_directories("libuv/include")
 	set(LIBUV_LIBRARIES uv_a)

--- a/cmake/FindLibUV.cmake
+++ b/cmake/FindLibUV.cmake
@@ -1,0 +1,34 @@
+#=============================================================================
+#  Copyright 2016 The Luvit Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#=============================================================================
+# Locate libuv library
+# This module defines
+#  LIBUV_FOUND, if false, do not try to link to libuv
+#  LIBUV_LIBRARIES
+#  LIBUV_INCLUDE_DIR, where to find uv.h
+
+FIND_PATH(LIBUV_INCLUDE_DIR NAMES uv.h)
+FIND_LIBRARY(LIBUV_LIBRARIES NAMES uv libuv)
+
+if(WIN32)
+    list(APPEND LIBUV_LIBRARIES iphlpapi)
+    list(APPEND LIBUV_LIBRARIES psapi)
+    list(APPEND LIBUV_LIBRARIES userenv)
+    list(APPEND LIBUV_LIBRARIES ws2_32)
+endif()
+
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LIBUV DEFAULT_MSG LIBUV_LIBRARIES LIBUV_INCLUDE_DIR)
+

--- a/cmake/FindMariaDB.cmake
+++ b/cmake/FindMariaDB.cmake
@@ -1,0 +1,76 @@
+# - Try to find MariaDB.
+# Once done this will define:
+# MARIADB_FOUND			- If false, do not try to use MariaDB.
+# MARIADB_INCLUDE_DIRS	- Where to find mysql.h, etc.
+# MARIADB_LIBRARIES		- The libraries to link against.
+# MARIADB_VERSION_STRING	- Version in a string of MariaDB.
+#
+# Created by RenatoUtsch based on eAthena implementation.
+#
+# Please note that this module only supports Windows and Linux officially, but
+# should work on all UNIX-like operational systems too.
+#
+
+#=============================================================================
+# Copyright 2012 RenatoUtsch
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+if( WIN32 )
+	find_path( MARIADB_INCLUDE_DIR
+		NAMES "mysql.h"
+		PATHS "$ENV{PROGRAMFILES}/MariaDB/*/include"
+			  "$ENV{PROGRAMFILES(x86)}/MariaDB/*/include"
+			  "$ENV{SYSTEMDRIVE}/MariaDB/*/include" )
+	
+	find_library( MARIADB_LIBRARY
+		NAMES "mariadb"
+		PATHS "$ENV{PROGRAMFILES}/MariaDB/*/lib"
+			  "$ENV{PROGRAMFILES(x86)}/MariaDB/*/lib"
+			  "$ENV{SYSTEMDRIVE}/MariaDB/*/lib" )
+else()
+	find_path( MARIADB_INCLUDE_DIR
+		NAMES "mysql.h"
+		PATHS "/usr/include/mariadb"
+			  "/usr/local/include/mariadb"
+			  "/usr/mysql/include/mariadb" )
+	
+	find_library( MARIADB_LIBRARY
+		NAMES "mariadb"
+		PATHS "/lib/mysql"
+			  "/lib64/mysql"
+			  "/usr/lib/mysql"
+			  "/usr/lib64/mysql"
+			  "/usr/local/lib/mysql"
+			  "/usr/local/lib64/mysql"
+			  "/usr/mysql/lib/mysql"
+			  "/usr/mysql/lib64/mysql" )
+endif()
+
+if( MARIADB_INCLUDE_DIR AND EXISTS "${MARIADB_INCLUDE_DIR}/mariadb_version.h" )
+	file( STRINGS "${MARIADB_INCLUDE_DIR}/mariadb_version.h"
+		MARIADB_VERSION_H REGEX "^#define[ \t]+MARIADB_CLIENT_VERSION_STR[ \t]+\"[^\"]+\".*$" )
+	string( REGEX REPLACE
+		"^.*MARIADB_CLIENT_VERSION_STR[ \t]+\"([^\"]+)\".*$" "\\1" MARIADB_VERSION_STRING
+		"${MARIADB_VERSION_H}" )    
+endif()
+
+# handle the QUIETLY and REQUIRED arguments and set MARIADB_FOUND to TRUE if
+# all listed variables are TRUE
+include( FindPackageHandleStandardArgs )
+find_package_handle_standard_args( MARIADB
+	REQUIRED_VARS	MARIADB_LIBRARY MARIADB_INCLUDE_DIR
+	VERSION_VAR		MARIADB_VERSION_STRING )
+
+set( MARIADB_INCLUDE_DIRS ${MARIADB_INCLUDE_DIR} )
+set( MARIADB_LIBRARIES ${MARIADB_LIBRARY} )
+
+mark_as_advanced( MARIADB_INCLUDE_DIR MARIADB_LIBRARY )


### PR DESCRIPTION
Adds some CMake modules to look for the MariaDB and LibUV libraries and link to the system versions if found.

Needs libmariadb-dev and libuv1-dev installed on Ubuntu 18.04 to successfully find them.